### PR TITLE
카프카 메시지 발행 아웃박스 패턴 구현

### DIFF
--- a/booking/build.gradle
+++ b/booking/build.gradle
@@ -30,6 +30,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 	implementation 'org.redisson:redisson-spring-boot-starter:3.22.1'
 	implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
+	implementation 'org.springframework.kafka:spring-kafka'
 
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.h2database:h2'
@@ -40,6 +41,12 @@ dependencies {
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 	testAnnotationProcessor 'org.projectlombok:lombok'
 	testCompileOnly 'org.projectlombok:lombok'
+
+	testImplementation 'org.springframework.kafka:spring-kafka-test'
+	testImplementation 'org.testcontainers:junit-jupiter'
+	testImplementation 'org.testcontainers:kafka'
+	testImplementation 'org.testcontainers:mysql'
+	testImplementation 'org.awaitility:awaitility'
 }
 
 tasks.named('test') {

--- a/booking/src/main/java/booking/api/concert/domain/Payment.java
+++ b/booking/src/main/java/booking/api/concert/domain/Payment.java
@@ -2,15 +2,17 @@ package booking.api.concert.domain;
 
 import booking.api.concert.domain.enums.PaymentState;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
 
 @Getter
+@NoArgsConstructor
 public class Payment {
 
-    private final Long id;
-    private final Long reservationId;
+    private Long id;
+    private Long reservationId;
     private BigDecimal price;
     private PaymentState paymentState;
     private LocalDateTime createdAt;

--- a/booking/src/main/java/booking/api/concert/domain/PaymentOutbox.java
+++ b/booking/src/main/java/booking/api/concert/domain/PaymentOutbox.java
@@ -1,0 +1,59 @@
+package booking.api.concert.domain;
+
+import booking.api.concert.domain.enums.PaymentOutboxState;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class PaymentOutbox {
+
+    private final Long id;
+    private final String uuid;
+    private final String payload;
+    private int publishedCount;
+    private boolean skipped;
+    private PaymentOutboxState paymentOutboxState;
+    private LocalDateTime createdAt;
+    private LocalDateTime modifiedAt;
+
+    @Builder
+    public PaymentOutbox(
+            Long id, String uuid, String payload, int publishedCount, boolean skipped,
+            PaymentOutboxState paymentOutboxState, LocalDateTime createdAt, LocalDateTime modifiedAt
+    ) {
+        this.id = id;
+        this.uuid = uuid;
+        this.payload = payload;
+        this.publishedCount = publishedCount;
+        this.skipped = skipped;
+        this.paymentOutboxState = paymentOutboxState;
+        this.createdAt = createdAt;
+        this.modifiedAt = modifiedAt;
+    }
+
+    public void publish() {
+        this.paymentOutboxState = PaymentOutboxState.PUBLISHED;
+    }
+
+    public void updateTime() {
+        this.modifiedAt = LocalDateTime.now();
+    }
+
+
+    public static PaymentOutbox create(String uuid, String payload) {
+        return PaymentOutbox.builder()
+                .uuid(uuid)
+                .payload(payload)
+                .publishedCount(0)
+                .skipped(false)
+                .paymentOutboxState(PaymentOutboxState.INIT)
+                .createdAt(LocalDateTime.now())
+                .build();
+    }
+
+    public void setTenMinAgo() {
+        this.createdAt = LocalDateTime.now().minusMinutes(10);
+    }
+}

--- a/booking/src/main/java/booking/api/concert/domain/Reservation.java
+++ b/booking/src/main/java/booking/api/concert/domain/Reservation.java
@@ -2,18 +2,20 @@ package booking.api.concert.domain;
 
 import booking.api.concert.domain.enums.ReservationStatus;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 @Getter
+@NoArgsConstructor
 public class Reservation {
 
-    private final Long id;
-    private final Long concertSeatId;
-    private final Long userId;
-    private final String concertName;
-    private final LocalDate concertDate;
+    private Long id;
+    private Long concertSeatId;
+    private Long userId;
+    private String concertName;
+    private LocalDate concertDate;
     private ReservationStatus reservationStatus;
     private LocalDateTime createdAt;
     private LocalDateTime modifiedAt;

--- a/booking/src/main/java/booking/api/concert/domain/enums/PaymentOutboxState.java
+++ b/booking/src/main/java/booking/api/concert/domain/enums/PaymentOutboxState.java
@@ -1,0 +1,5 @@
+package booking.api.concert.domain.enums;
+
+public enum PaymentOutboxState {
+    INIT, PUBLISHED
+}

--- a/booking/src/main/java/booking/api/concert/domain/event/PaymentSuccessEvent.java
+++ b/booking/src/main/java/booking/api/concert/domain/event/PaymentSuccessEvent.java
@@ -7,9 +7,12 @@ import lombok.Getter;
 @Getter
 public class PaymentSuccessEvent {
 
-    private final Reservation reservation;
-    private final Payment payment;
-    private final String token;
+    private Reservation reservation;
+    private Payment payment;
+    private String token;
+
+    public PaymentSuccessEvent() {
+    }
 
     public PaymentSuccessEvent(Reservation reservation, Payment payment, String token) {
         this.reservation = reservation;

--- a/booking/src/main/java/booking/api/concert/domain/message/PaymentMessage.java
+++ b/booking/src/main/java/booking/api/concert/domain/message/PaymentMessage.java
@@ -1,0 +1,26 @@
+package booking.api.concert.domain.message;
+
+import booking.api.concert.domain.event.PaymentSuccessEvent;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.UUID;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+public class PaymentMessage<T> {
+
+    String messageId;
+    T payLoad;
+
+    public static PaymentMessage<PaymentSuccessEvent> create(PaymentSuccessEvent payLoad) {
+        String uuid = UUID.randomUUID().toString();
+        return new PaymentMessage<>(uuid, payLoad);
+    }
+
+    public static PaymentMessage<PaymentSuccessEvent> of(String uuid, PaymentSuccessEvent payLoad) {
+        return new PaymentMessage<>(uuid, payLoad);
+    }
+}

--- a/booking/src/main/java/booking/api/concert/domain/message/PaymentMessageOutbox.java
+++ b/booking/src/main/java/booking/api/concert/domain/message/PaymentMessageOutbox.java
@@ -1,0 +1,22 @@
+package booking.api.concert.domain.message;
+
+import booking.api.concert.domain.PaymentOutbox;
+import booking.api.concert.domain.enums.PaymentOutboxState;
+import booking.api.concert.domain.event.PaymentSuccessEvent;
+
+import java.util.List;
+
+public interface PaymentMessageOutbox {
+
+    PaymentOutbox save(PaymentMessage<PaymentSuccessEvent> message);
+
+    void complete(PaymentMessage<PaymentSuccessEvent> message);
+
+    PaymentOutbox findByUuid(String uuid);
+
+    List<PaymentOutbox> findAll();
+
+    List<PaymentOutbox> findAllByStatus(PaymentOutboxState paymentOutboxState);
+
+    PaymentOutbox entitySave(PaymentOutbox paymentOutbox);
+}

--- a/booking/src/main/java/booking/api/concert/domain/message/PaymentMessageSender.java
+++ b/booking/src/main/java/booking/api/concert/domain/message/PaymentMessageSender.java
@@ -1,0 +1,8 @@
+package booking.api.concert.domain.message;
+
+import booking.api.concert.domain.event.PaymentSuccessEvent;
+
+public interface PaymentMessageSender {
+
+    void send(PaymentMessage<PaymentSuccessEvent> message);
+}

--- a/booking/src/main/java/booking/api/concert/infrastructure/db/PaymentOutboxEntity.java
+++ b/booking/src/main/java/booking/api/concert/infrastructure/db/PaymentOutboxEntity.java
@@ -1,0 +1,93 @@
+package booking.api.concert.infrastructure.db;
+
+import booking.api.concert.domain.PaymentOutbox;
+import booking.api.concert.domain.enums.PaymentOutboxState;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Comment;
+
+import java.time.LocalDateTime;
+import java.util.Objects;
+
+@Entity @Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "payment_outbox")
+public class PaymentOutboxEntity {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Comment("식별자 PK")
+    private Long id;
+
+    @Comment("UUID")
+    private String uuid;
+
+    @Comment("메시지")
+    private String payload;
+
+    @Comment("발행 재시도 가능 횟수")
+    private int publishedCount;
+
+    @Comment("요청 금지 상태")
+    private boolean skipped;
+
+    @Enumerated(EnumType.STRING)
+    @Comment("아웃박스 상태")
+    private PaymentOutboxState paymentOutboxState;
+
+    @Comment("생성 시간")
+    private LocalDateTime createdAt;
+
+    @Comment("변경 시간")
+    private LocalDateTime modifiedAt;
+
+    @Builder
+    public PaymentOutboxEntity(
+            Long id, String uuid, String payload, PaymentOutboxState paymentOutboxState,
+            LocalDateTime createdAt, LocalDateTime modifiedAt
+    ) {
+        this.id = id;
+        this.uuid = uuid;
+        this.payload = payload;
+        this.paymentOutboxState = paymentOutboxState;
+        this.createdAt = createdAt;
+        this.modifiedAt = modifiedAt;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        PaymentOutboxEntity paymentOutboxEntity = (PaymentOutboxEntity) o;
+        return Objects.equals(uuid, paymentOutboxEntity.uuid);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(uuid);
+    }
+
+    public static PaymentOutboxEntity of(PaymentOutbox paymentOutbox) {
+        return PaymentOutboxEntity.builder()
+                .id(paymentOutbox.getId())
+                .uuid(paymentOutbox.getUuid())
+                .payload(paymentOutbox.getPayload())
+                .paymentOutboxState(paymentOutbox.getPaymentOutboxState())
+                .createdAt(paymentOutbox.getCreatedAt())
+                .modifiedAt(paymentOutbox.getModifiedAt())
+                .build();
+    }
+
+    public static PaymentOutbox toDomain(PaymentOutboxEntity entity) {
+        return PaymentOutbox.builder()
+                .id(entity.getId())
+                .uuid(entity.getUuid())
+                .payload(entity.getPayload())
+                .paymentOutboxState(entity.getPaymentOutboxState())
+                .createdAt(entity.getCreatedAt())
+                .modifiedAt(entity.getModifiedAt())
+                .build();
+    }
+}

--- a/booking/src/main/java/booking/api/concert/infrastructure/db/repository/JpaPaymentOutboxRepository.java
+++ b/booking/src/main/java/booking/api/concert/infrastructure/db/repository/JpaPaymentOutboxRepository.java
@@ -1,0 +1,18 @@
+package booking.api.concert.infrastructure.db.repository;
+
+import booking.api.concert.domain.enums.PaymentOutboxState;
+import booking.api.concert.infrastructure.db.PaymentOutboxEntity;
+import io.lettuce.core.dynamic.annotation.Param;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
+
+public interface JpaPaymentOutboxRepository extends JpaRepository<PaymentOutboxEntity, Long> {
+
+    @Query("SELECT po FROM PaymentOutboxEntity po WHERE po.uuid = :uuid")
+    PaymentOutboxEntity findByUuid(@Param("uuid") String uuid);
+
+    @Query("SELECT po FROM PaymentOutboxEntity po WHERE po.paymentOutboxState = :paymentOutboxState")
+    List<PaymentOutboxEntity> findAllByStatus(@Param("paymentOutboxState") PaymentOutboxState paymentOutboxState);
+}

--- a/booking/src/main/java/booking/api/concert/infrastructure/db/repository/PaymentMessageOutboxImpl.java
+++ b/booking/src/main/java/booking/api/concert/infrastructure/db/repository/PaymentMessageOutboxImpl.java
@@ -1,0 +1,63 @@
+package booking.api.concert.infrastructure.db.repository;
+
+import booking.api.concert.domain.PaymentOutbox;
+import booking.api.concert.domain.enums.PaymentOutboxState;
+import booking.api.concert.domain.event.PaymentSuccessEvent;
+import booking.api.concert.domain.message.PaymentMessage;
+import booking.api.concert.domain.message.PaymentMessageOutbox;
+import booking.api.concert.infrastructure.db.PaymentOutboxEntity;
+import booking.support.JsonUtil;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class PaymentMessageOutboxImpl implements PaymentMessageOutbox {
+
+    private final JpaPaymentOutboxRepository jpaPaymentOutboxRepository;
+
+    @Override
+    public PaymentOutbox save(PaymentMessage<PaymentSuccessEvent> message) {
+        String payload = JsonUtil.toJson(message);
+        PaymentOutbox paymentOutbox = PaymentOutbox.create(message.getMessageId(), payload);
+        PaymentOutboxEntity entity = jpaPaymentOutboxRepository.save(PaymentOutboxEntity.of(paymentOutbox));
+        return PaymentOutboxEntity.toDomain(entity);
+    }
+
+    @Override
+    public void complete(PaymentMessage<PaymentSuccessEvent> message) {
+        PaymentOutboxEntity entity = jpaPaymentOutboxRepository.findByUuid(message.getMessageId());
+        PaymentOutbox paymentOutbox = PaymentOutboxEntity.toDomain(entity);
+        paymentOutbox.publish();
+        paymentOutbox.updateTime();
+        jpaPaymentOutboxRepository.save(PaymentOutboxEntity.of(paymentOutbox));
+    }
+
+    @Override
+    public PaymentOutbox findByUuid(String uuid) {
+        return PaymentOutboxEntity.toDomain(jpaPaymentOutboxRepository.findByUuid(uuid));
+    }
+
+    @Override
+    public List<PaymentOutbox> findAll() {
+        List<PaymentOutboxEntity> entities = jpaPaymentOutboxRepository.findAll();
+        return entities.stream()
+                .map(PaymentOutboxEntity::toDomain)
+                .toList();
+    }
+
+    @Override
+    public List<PaymentOutbox> findAllByStatus(PaymentOutboxState paymentOutboxState) {
+        List<PaymentOutboxEntity> entities = jpaPaymentOutboxRepository.findAllByStatus(paymentOutboxState);
+        return entities.stream()
+                .map(PaymentOutboxEntity::toDomain)
+                .toList();
+    }
+
+    @Override
+    public PaymentOutbox entitySave(PaymentOutbox paymentOutbox) {
+        return PaymentOutboxEntity.toDomain(jpaPaymentOutboxRepository.save(PaymentOutboxEntity.of(paymentOutbox)));
+    }
+}

--- a/booking/src/main/java/booking/api/concert/infrastructure/kafka/PaymentKafkaMessageSender.java
+++ b/booking/src/main/java/booking/api/concert/infrastructure/kafka/PaymentKafkaMessageSender.java
@@ -1,0 +1,34 @@
+package booking.api.concert.infrastructure.kafka;
+
+import booking.api.concert.domain.event.PaymentSuccessEvent;
+import booking.api.concert.domain.message.PaymentMessage;
+import booking.api.concert.domain.message.PaymentMessageSender;
+import booking.support.JsonUtil;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class PaymentKafkaMessageSender implements PaymentMessageSender {
+
+    private final KafkaTemplate<String, String> kafkaTemplate;
+
+    @Value("${payment.topic-name}")
+    private String paymentTopic;
+
+    @Override
+    public void send(PaymentMessage<PaymentSuccessEvent> message) {
+        String payload = JsonUtil.toJson(message);
+        kafkaTemplate.send(paymentTopic, payload).whenComplete((result, exception) -> {
+            if (exception != null) {
+                log.error("[Kafka - Send] Failed to send payload. Error: {}", exception.getMessage(), exception);
+            } else {
+                log.info("[Kafka - Send] Payload sent successfully. Payload: {}", payload);
+            }
+        });
+    }
+}

--- a/booking/src/main/java/booking/api/concert/interfaces/consumer/PaymentMessageConsumer.java
+++ b/booking/src/main/java/booking/api/concert/interfaces/consumer/PaymentMessageConsumer.java
@@ -1,0 +1,32 @@
+package booking.api.concert.interfaces.consumer;
+
+import booking.api.concert.domain.event.PaymentSuccessEvent;
+import booking.api.concert.domain.message.PaymentMessage;
+import booking.api.concert.domain.message.PaymentMessageOutbox;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class PaymentMessageConsumer {
+
+    private final ObjectMapper objectMapper;
+    private final PaymentMessageOutbox paymentMessageOutbox;
+
+    @KafkaListener(topics = "${payment.topic-name}", groupId = "${spring.application.name}")
+    void complete(String message) {
+        try {
+            PaymentMessage<PaymentSuccessEvent> paymentMessage =
+                    objectMapper.readValue(message, objectMapper.getTypeFactory()
+                            .constructParametricType(PaymentMessage.class, PaymentSuccessEvent.class));
+            log.info("[Kafka - Consume] message consume success = {}", paymentMessage);
+            paymentMessageOutbox.complete(paymentMessage);
+        } catch (Exception e) {
+            log.error("Failed to parse message", e);
+        }
+    }
+}

--- a/booking/src/main/java/booking/api/concert/interfaces/event/PaymentEventListener.java
+++ b/booking/src/main/java/booking/api/concert/interfaces/event/PaymentEventListener.java
@@ -1,27 +1,54 @@
 package booking.api.concert.interfaces.event;
 
 import booking.api.concert.application.DataPlatformSendService;
+import booking.api.concert.domain.PaymentOutbox;
 import booking.api.concert.domain.event.PaymentSuccessEvent;
+import booking.api.concert.domain.message.PaymentMessage;
+import booking.api.concert.domain.message.PaymentMessageOutbox;
+import booking.api.concert.domain.message.PaymentMessageSender;
 import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
+
+import static org.springframework.transaction.event.TransactionPhase.AFTER_COMMIT;
+import static org.springframework.transaction.event.TransactionPhase.BEFORE_COMMIT;
 
 @Component
 @RequiredArgsConstructor
 public class PaymentEventListener {
 
+    private static final Logger logger = LoggerFactory.getLogger(PaymentEventListener.class);
+
     private final DataPlatformSendService sendService;
+    private final PaymentMessageOutbox paymentMessageOutbox;
+    private final PaymentMessageSender paymentMessageSender;
+
+    private PaymentOutbox paymentOutbox = null;
+
+    @TransactionalEventListener(phase = BEFORE_COMMIT)
+    void createOutboxMessage(PaymentSuccessEvent event) {
+        paymentOutbox = paymentMessageOutbox.save(PaymentMessage.create(event));
+    }
 
     @Async
-    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    @TransactionalEventListener(phase = AFTER_COMMIT)
+    void sendMessage(PaymentSuccessEvent event) {
+        logger.info("[Kafka - Listener] event send success = {}", event);
+        String uuid = paymentOutbox.getUuid();
+        paymentMessageSender.send(PaymentMessage.of(uuid, event));
+    }
+
+    @Async
+    @TransactionalEventListener(phase = AFTER_COMMIT)
     public void expireToken(PaymentSuccessEvent event) {
         sendService.expireToken(event.getToken());
     }
 
     @Async
-    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    @TransactionalEventListener(phase = AFTER_COMMIT)
     public void sendSlack(PaymentSuccessEvent event) {
         sendService.sendSlack(event.getReservation(), event.getPayment());
     }

--- a/booking/src/main/java/booking/support/JsonUtil.java
+++ b/booking/src/main/java/booking/support/JsonUtil.java
@@ -1,0 +1,42 @@
+package booking.support;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class JsonUtil {
+
+    private static final ObjectMapper mapper = new ObjectMapper();
+
+    static {
+        //Jackson ObjectMapper 설정
+        mapper.registerModule(new JavaTimeModule());
+        mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+        mapper.configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false);
+    }
+
+    private JsonUtil() {
+    }
+
+    public static String toJson(Object target) {
+        try {
+            return mapper.writeValueAsString(target);
+        } catch (JsonProcessingException e) {
+            log.error("[JsonUtil] toJson processing error = {}", e.getMessage());
+            return null;
+        }
+    }
+
+    public static <T> T fromJson(String json, Class<T> clazz) {
+        try {
+            return mapper.readValue(json, clazz);
+        } catch (JsonProcessingException e) {
+            log.error("[JsonUtil] fromJson processing error = {}", e.getMessage());
+            return null;
+        }
+    }
+}

--- a/booking/src/main/java/booking/support/config/KafkaConfig.java
+++ b/booking/src/main/java/booking/support/config/KafkaConfig.java
@@ -1,0 +1,36 @@
+package booking.support.config;
+
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.core.ProducerFactory;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Configuration
+public class KafkaConfig {
+
+    @Value("${spring.kafka.bootstrap-servers}")
+    private String bootstrapServers;
+
+    @Bean
+    public ProducerFactory<String, String> producerFactory() {
+        Map<String, Object> configs = new HashMap<>();
+        configs.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+        configs.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        configs.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        configs.put(ProducerConfig.ACKS_CONFIG, "all"); //모든 복제본에서 확인을 요구
+        configs.put(ProducerConfig.RETRIES_CONFIG, 3);  //실패 시 재시도 횟수 설정
+        return new DefaultKafkaProducerFactory<>(configs);
+    }
+
+    @Bean
+    public KafkaTemplate<String, String> kafkaTemplate() {
+        return new KafkaTemplate<>(producerFactory());
+    }
+}

--- a/booking/src/main/java/booking/support/scheduler/KafkaRepublishScheduler.java
+++ b/booking/src/main/java/booking/support/scheduler/KafkaRepublishScheduler.java
@@ -1,0 +1,48 @@
+package booking.support.scheduler;
+
+import booking.api.concert.domain.PaymentOutbox;
+import booking.api.concert.domain.event.PaymentSuccessEvent;
+import booking.api.concert.domain.message.PaymentMessage;
+import booking.api.concert.domain.message.PaymentMessageOutbox;
+import booking.api.concert.domain.message.PaymentMessageSender;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static booking.api.concert.domain.enums.PaymentOutboxState.INIT;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class KafkaRepublishScheduler {
+
+    private final PaymentMessageOutbox paymentMessageOutbox;
+    private final PaymentMessageSender paymentMessageSender;
+    private final ObjectMapper objectMapper;
+
+    //매 5초마다 카프카 재발행
+    @Scheduled(fixedRate = 5000)
+    public void republish() {
+        List<PaymentOutbox> paymentOutboxes = paymentMessageOutbox.findAllByStatus(INIT);
+
+        paymentOutboxes.stream()
+                .filter(paymentOutbox -> paymentOutbox.getCreatedAt().isBefore(LocalDateTime.now().minusMinutes(5)))
+                .forEach(paymentOutbox -> {
+                    try {
+                        PaymentMessage<PaymentSuccessEvent> paymentMessage =
+                                objectMapper.readValue(paymentOutbox.getPayload(),
+                                        objectMapper.getTypeFactory()
+                                                .constructParametricType(PaymentMessage.class, PaymentSuccessEvent.class));
+                        paymentMessageSender.send(paymentMessage);
+                    } catch (JsonProcessingException e) {
+                        log.error("[Kafka - Scheduler] exception = {}", e.getMessage());
+                    }
+                });
+    }
+}

--- a/booking/src/main/resources/application.yml
+++ b/booking/src/main/resources/application.yml
@@ -19,3 +19,21 @@ spring:
         show_sql: true
         format_sql: true
         dialect: org.hibernate.dialect.MySQLDialect
+  kafka:
+    bootstrap-servers: localhost:9092
+    consumer:
+      group-id: ${spring.application.name}
+      auto-offset-reset: earliest
+      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      value-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+    producer:
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+      value-serializer: org.apache.kafka.common.serialization.StringSerializer
+  async:
+    execution:
+      pool:
+        core-size: 5
+        max-size: 10
+        queue-capacity: 25
+payment:
+  topic-name: "payment-success"

--- a/booking/src/test/java/booking/api/concert/integration/KafkaIntegrationTest.java
+++ b/booking/src/test/java/booking/api/concert/integration/KafkaIntegrationTest.java
@@ -1,0 +1,50 @@
+package booking.api.concert.integration;
+
+import booking.api.concert.domain.ConcertService;
+import booking.api.concert.domain.PaymentOutbox;
+import booking.api.concert.domain.enums.PaymentOutboxState;
+import booking.api.concert.domain.message.PaymentMessageOutbox;
+import booking.api.concert.interfaces.consumer.PaymentMessageConsumer;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.kafka.test.context.EmbeddedKafka;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@Slf4j
+@ActiveProfiles("test")
+@EmbeddedKafka(partitions = 1, brokerProperties = { "listeners=PLAINTEXT://localhost:9092", "port=9092" })
+public class KafkaIntegrationTest {
+
+    @Autowired
+    public PaymentMessageOutbox paymentMessageOutbox;
+
+    @Autowired
+    public ConcertService concertService;
+
+    @Autowired
+    public PaymentMessageConsumer paymentMessageConsumer;
+
+    @Test
+    @DisplayName("카프카 발행 및 컨슘 후 아웃박스 PUBLISHED 상태 테스트")
+    public void outboxSaveTest() throws InterruptedException {
+
+        String token = "f8d007a8-7459-480d-8434-cd3690763499";
+
+        concertService.pay(1L, 1L, token);
+        List<PaymentOutbox> paymentOutboxList = paymentMessageOutbox.findAll();
+        String uuid = paymentOutboxList.get(0).getUuid();
+
+        Thread.sleep(2000);
+
+        PaymentOutbox paymentOutbox = paymentMessageOutbox.findByUuid(uuid);
+        assertThat(paymentOutbox.getPaymentOutboxState()).isEqualTo(PaymentOutboxState.PUBLISHED);
+    }
+}

--- a/booking/src/test/java/booking/api/concert/integration/KafkaPublisherTest.java
+++ b/booking/src/test/java/booking/api/concert/integration/KafkaPublisherTest.java
@@ -1,0 +1,97 @@
+package booking.api.concert.integration;
+
+import booking.api.concert.domain.Payment;
+import booking.api.concert.domain.Reservation;
+import booking.api.concert.domain.enums.PaymentState;
+import booking.api.concert.domain.enums.ReservationStatus;
+import booking.api.concert.domain.event.PaymentSuccessEvent;
+import booking.api.concert.domain.message.PaymentMessage;
+import booking.support.JsonUtil;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.context.TestPropertySource;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.kafka.KafkaContainer;
+import org.testcontainers.utility.DockerImageName;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@SpringBootTest
+@TestPropertySource(
+        properties = {
+                "spring.kafka.consumer.auto-offset-reset=earliest",
+                "spring.datasource.url=jdbc:h2:mem:test;MODE=MySQL;NON_KEYWORDS=USER",
+                "payment.topic-name=payment-success",
+                "spring.async.execution.pool.core-size=5",
+                "spring.async.execution.pool.max-size=10",
+                "spring.async.execution.pool.queue-capacity=25"
+        }
+)
+@Testcontainers
+@Slf4j
+public class KafkaPublisherTest {
+
+    @Container
+    static final KafkaContainer kafkaContainer = new KafkaContainer(
+            DockerImageName.parse("apache/kafka:3.7.0"));
+
+    @Container
+    static final MySQLContainer<?> mysqlContainer = new MySQLContainer<>(
+            DockerImageName.parse("mysql:latest"));
+
+    @Container
+    static final GenericContainer<?> redisContainer = new GenericContainer<>(
+            DockerImageName.parse("redis:latest"))
+            .withExposedPorts(6379);
+
+    @DynamicPropertySource
+    static void dynamicProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.kafka.bootstrap-servers", kafkaContainer::getBootstrapServers);
+        registry.add("spring.kafka.consumer.bootstrap-servers", kafkaContainer::getBootstrapServers);
+        registry.add("spring.kafka.producer.bootstrap-servers", kafkaContainer::getBootstrapServers);
+
+        registry.add("spring.datasource.url", mysqlContainer::getJdbcUrl);
+        registry.add("spring.datasource.username", mysqlContainer::getUsername);
+        registry.add("spring.datasource.password", mysqlContainer::getPassword);
+
+        registry.add("spring.data.redis.host", redisContainer::getHost);
+        registry.add("spring.data.redis.port", redisContainer::getFirstMappedPort);
+    }
+
+    @Autowired
+    public KafkaTemplate<String, String> kafkaTemplate;
+
+    @Test
+    @DisplayName("카프카 메시지 발행 성공 테스트")
+    public void messageSendTest() {
+
+        Reservation reservation = new Reservation(1L, 1L, 1L, "Concert 1",
+                LocalDate.parse("2024-08-15"), ReservationStatus.RESERVING, LocalDateTime.now(), null);
+        Payment payment = new Payment(1L, 1L, BigDecimal.valueOf(1000), PaymentState.PENDING, LocalDateTime.now(), null);
+        String token = "f8d007a8-7459-480d-8434-cd3690763499";
+
+        String uuid = "test";
+        PaymentSuccessEvent event = new PaymentSuccessEvent(reservation, payment, token);
+        PaymentMessage<PaymentSuccessEvent> message = new PaymentMessage<>(uuid, event);
+        String payload = JsonUtil.toJson(message);
+
+        kafkaTemplate.send("payment-success", payload).whenComplete((result, exception) -> {
+            if (exception != null) {
+                log.error("[Kafka - Send] Failed to send payload. Error: {}", exception.getMessage(), exception);
+            } else {
+                log.info("[Kafka - Send] Payload sent successfully. Payload: {}", payload);
+            }
+        });
+    }
+}

--- a/booking/src/test/java/booking/support/scheduler/KafkaRepublishSchedulerTest.java
+++ b/booking/src/test/java/booking/support/scheduler/KafkaRepublishSchedulerTest.java
@@ -1,0 +1,96 @@
+package booking.support.scheduler;
+
+import booking.api.concert.domain.Payment;
+import booking.api.concert.domain.PaymentOutbox;
+import booking.api.concert.domain.Reservation;
+import booking.api.concert.domain.enums.PaymentState;
+import booking.api.concert.domain.enums.ReservationStatus;
+import booking.api.concert.domain.event.PaymentSuccessEvent;
+import booking.api.concert.domain.message.PaymentMessage;
+import booking.api.concert.domain.message.PaymentMessageOutbox;
+import booking.support.JsonUtil;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.test.context.EmbeddedKafka;
+import org.springframework.scheduling.annotation.ScheduledAnnotationBeanPostProcessor;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+import static booking.api.concert.domain.enums.PaymentOutboxState.INIT;
+import static booking.api.concert.domain.enums.PaymentOutboxState.PUBLISHED;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@Slf4j
+@ActiveProfiles("test")
+@EmbeddedKafka(partitions = 1, brokerProperties = { "listeners=PLAINTEXT://localhost:9092", "port=9092" })
+class KafkaRepublishSchedulerTest {
+
+    @Autowired
+    public PaymentMessageOutbox paymentMessageOutbox;
+
+    @Autowired
+    public KafkaTemplate<String, String> kafkaTemplate;
+
+    @Autowired
+    private KafkaRepublishScheduler kafkaRepublishScheduler;
+
+    @Autowired
+    private ScheduledAnnotationBeanPostProcessor postProcessor;
+
+    @BeforeEach
+    void setUp() {
+        //스케줄러 초기화
+        postProcessor.postProcessAfterInitialization(kafkaRepublishScheduler, "kafkaRepublishScheduler");
+    }
+
+    @Test
+    @DisplayName("스케줄러가 동작한 후의 아웃박스 상태는 PUBLISHED 상태여야 한다.")
+    void republishTest() throws InterruptedException {
+        Reservation reservation = new Reservation(1L, 1L, 1L, "Concert 1",
+                LocalDate.parse("2024-08-15"), ReservationStatus.RESERVING, LocalDateTime.now(), null);
+        Payment payment = new Payment(1L, 1L, BigDecimal.valueOf(1000), PaymentState.PENDING, LocalDateTime.now(), null);
+        String token = "f8d007a8-7459-480d-8434-cd3690763499";
+
+        String uuid = "test";
+        PaymentSuccessEvent event = new PaymentSuccessEvent(reservation, payment, token);
+        PaymentMessage<PaymentSuccessEvent> message = new PaymentMessage<>(uuid, event);
+        String payload = JsonUtil.toJson(message);
+
+        //아웃박스 생성
+        PaymentOutbox paymentOutbox = paymentMessageOutbox.save(message);
+        paymentOutbox.setTenMinAgo(); //10분 전 데이터로 설정
+        paymentMessageOutbox.entitySave(paymentOutbox);
+
+        //카프카 메시지 발행
+        kafkaTemplate.send("payment-success", payload).whenComplete((result, exception) -> {
+            if (exception != null) {
+                log.error("[Kafka - Send] Failed to send payload. Error: {}", exception.getMessage(), exception);
+            } else {
+                log.info("[Kafka - Send] Payload sent successfully. Payload: {}", payload);
+            }
+        });
+
+        //스케줄러 동작 전 INIT 상태
+        assertThat(paymentOutbox.getPaymentOutboxState()).isEqualTo(INIT);
+
+        //스케줄러 호출
+        kafkaRepublishScheduler.republish();
+
+        //5초 대기
+        Thread.sleep(5000);
+
+        //스케줄러 동작 후 PUBLISHED 상태
+        PaymentOutbox updatedOutbox = paymentMessageOutbox.findByUuid(paymentOutbox.getUuid());
+        assertThat(updatedOutbox.getPaymentOutboxState()).isEqualTo(PUBLISHED);
+    }
+
+}

--- a/booking/src/test/resources/application.yml
+++ b/booking/src/test/resources/application.yml
@@ -27,4 +27,22 @@ spring:
     init:
       mode: always
       schema-locations: classpath:/db/schema.sql
-      data-locations: classpath:/db/data.sql
+      data-locations: classpath:/db/testData.sql
+  kafka:
+    bootstrap-servers: localhost:9092
+    consumer:
+      group-id: ${spring.application.name}
+      auto-offset-reset: earliest
+      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      value-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+    producer:
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+      value-serializer: org.apache.kafka.common.serialization.StringSerializer
+  async:
+    execution:
+      pool:
+        core-size: 5
+        max-size: 10
+        queue-capacity: 25
+payment:
+  topic-name: "payment-success"

--- a/booking/src/test/resources/db/data.sql
+++ b/booking/src/test/resources/db/data.sql
@@ -53,3 +53,11 @@ FROM
         FROM number_sequence
         LIMIT 50
     ) sr;
+
+-- 예약 데이터 삽입
+INSERT INTO reservation (concert_seat_id, user_id, concert_name, concert_date, reservation_status, created_at, modified_at)
+values (1, 1, 'Concert 1', '2024-08-07', 'RESERVING', now(), null);
+
+-- 결제 데이터 삽입
+INSERT INTO payment (reservation_id, price, payment_state, created_at, modified_at)
+values (1, 1000, 'PENDING', now(), null);

--- a/booking/src/test/resources/db/schema.sql
+++ b/booking/src/test/resources/db/schema.sql
@@ -70,3 +70,16 @@ CREATE TABLE IF NOT EXISTS payment (
     PRIMARY KEY (id),
     UNIQUE (reservation_id)
 ) ENGINE=InnoDB;
+
+-- 결제 아웃박스
+DROP TABLE IF EXISTS payment_outbox;
+CREATE TABLE payment_outbox (
+    id INT NOT NULL AUTO_INCREMENT PRIMARY KEY COMMENT '식별자 PK',
+    uuid VARCHAR(255) NOT NULL COMMENT 'UUID',
+    payload TEXT COMMENT '메시지',
+    published_count INT DEFAULT 0 COMMENT '발행 재시도 가능 횟수',
+    skipped BOOLEAN DEFAULT FALSE COMMENT '요청 금지 상태',
+    payment_outbox_state VARCHAR(255) COMMENT '아웃박스 상태',
+    created_at TIMESTAMP COMMENT '생성 시간',
+    modified_at TIMESTAMP COMMENT '변경 시간'
+) ENGINE=InnoDB;

--- a/booking/src/test/resources/db/testData.sql
+++ b/booking/src/test/resources/db/testData.sql
@@ -1,0 +1,15 @@
+INSERT INTO user (amount) VALUES (1000);
+INSERT INTO user (amount) VALUES (2000);
+
+INSERT INTO concert (name, host) VALUES ('Rock Fest', 'Rock Inc.');
+INSERT INTO concert (name, host) VALUES ('Jazz Night', 'Jazz Corp.');
+
+INSERT INTO concert_schedule (concert_id, concert_date) VALUES (1, '2024-08-15');
+INSERT INTO concert_schedule (concert_id, concert_date) VALUES (2, '2024-09-01');
+
+INSERT INTO concert_seat (concert_id, concert_schedule_id, seat_number, seat_price, seat_status) VALUES (1, 1, 1, 100, 'AVAILABLE');
+INSERT INTO concert_seat (concert_id, concert_schedule_id, seat_number, seat_price, seat_status) VALUES (1, 1, 2, 100, 'AVAILABLE');
+
+INSERT INTO reservation (concert_seat_id, user_id, concert_name, concert_date, reservation_status, created_at) VALUES (1, 1, 'Rock Fest', '2024-08-15', 'RESERVING', NOW());
+
+INSERT INTO payment (reservation_id, price, payment_state, created_at) VALUES (1, 100, 'PENDING', NOW());


### PR DESCRIPTION
# 구현 완료
- application.yml 파일 설정
- testcontainers, kafka gradle dependency 추가
- Payment, Reservation, PaymentSuccessEvent 기본 생성자 설정
- 아웃박스 패턴 카프카 구현
- 아웃박스 테이블 schema 추가
- objectMapper 커스텀 파일 JsonUtil 추가
- KafkaConfig 설정
- 카프카 발행 및 컨슘, 아웃박스 상태 체크, 스케줄러 테스트 완료
- 카프카 발행 실패 건 재발행 스케줄러 구현

# To Reviewers
- 카프카를 아웃박스 패턴을 이용해서 잘 적용하였는지
- 필요한 테스트 요구사항이 구현되었는지

---

리뷰 해주셔서 감사합니다 ( _ _) 좋은 하루 되세요! 👍🏻